### PR TITLE
Optimization: avoid setting role_name for each function call

### DIFF
--- a/drf_roles/mixins.py
+++ b/drf_roles/mixins.py
@@ -29,8 +29,9 @@ class RoleViewSetMixin(object):
     def _call_role_fn(self, fn, *args, **kwargs):
         """Attempts to call a role-scoped method"""
         try:
-            role_name = self._get_role(self.request.user)
-            role_fn = "{}_for_{}".format(fn, role_name)
+            if not getattr(self, '_role_name', None):
+                self._role_name = self._get_role(self.request.user)
+            role_fn = "{}_for_{}".format(fn, self._role_name)
             return getattr(self, role_fn)(*args, **kwargs)
         except (AttributeError, RoleError):
             return getattr(super(RoleViewSetMixin, self), fn)(*args, **kwargs)


### PR DESCRIPTION
I notice that when using the mixin, there are multiple repeated db calls to get the user's role name:

For example, I can see the following statement appearing 5 times for one request.
```SQL
SELECT `auth_group`.`id`, `auth_group`.`name` FROM `auth_group` INNER JOIN `authuser_groups` ON (`auth_group`.`id` = `authuser_groups`.`group_id`) WHERE `authuser_groups`.`authuser_id` = 6
```
The reason is because `_get_role()` is called for each function in the `VIEWSET_METHOD_REGISTRY`, which involves a call to the db each time.  

There is a simple performance enhancement which is to retain the `role_name` value on the object.  I cannot foresee any issues with this, since the object exists for the lifetime of the request.
